### PR TITLE
Update Peer Online/Offline Parsing and Add Peer Data

### DIFF
--- a/backend/services/member.js
+++ b/backend/services/member.js
@@ -37,13 +37,18 @@ async function getMemberAdditionalData(data) {
   let peerData = {};
   if (peer) {
     peerData.latency = peer.latency;
-    peerData.online = peer.latency !== -1;
+    if (peer.latency !== -1)
+      peerData.online = 1;
+    if (peer.latency == -1)
+      peerData.online = 2;
     peerData.clientVersion = peer.version;
     if (peer.paths[0]) {
       peerData.lastOnline = peer.paths[0].lastReceive;
       peerData.physicalAddress = peer.paths[0].address.split("/")[0];
     }
   }
+  else
+    peerData.online = 0;
 
   delete data.lastAuthorizedCredential;
   delete data.lastAuthorizedCredentialType;

--- a/backend/services/member.js
+++ b/backend/services/member.js
@@ -45,10 +45,13 @@ async function getMemberAdditionalData(data) {
     if (peer.paths[0]) {
       peerData.lastOnline = peer.paths[0].lastReceive;
       peerData.physicalAddress = peer.paths[0].address.split("/")[0];
+      peerData.physicalPort = peer.paths[0].address.split("/")[1];
     }
   }
   else
+  {
     peerData.online = 0;
+  }
 
   delete data.lastAuthorizedCredential;
   delete data.lastAuthorizedCredentialType;

--- a/frontend/src/components/NetworkMembers/NetworkMembers.jsx
+++ b/frontend/src/components/NetworkMembers/NetworkMembers.jsx
@@ -101,19 +101,29 @@ function NetworkMembers({ network }) {
       name: "Peer status",
       minWidth: "100px",
       cell: (row) =>
-        row.online ? (
-          <Typography style={{ color: "#008000" }}>
-            {"ONLINE (v" +
-              row.config.vMajor +
-              "." +
-              row.config.vMinor +
-              "." +
-              row.config.vRev +
-              ")"}
-          </Typography>
-        ) : (
+        (row.online == 0) ? (
           <Typography color="error">OFFLINE</Typography>
-        ),
+        ) : ( (row.online == 1) ? (
+        
+            <Typography style={{ color: "#008000" }}>
+              {"ONLINE (v" +
+                row.config.vMajor +
+                "." +
+                row.config.vMinor +
+                "." +
+                row.config.vRev +
+                ")"}
+            </Typography>
+         ) : (
+            <Typography style={{ color: "#f1c232" }}>
+              {"RELAYED (v" +
+                row.config.vMajor +
+                "." +
+                row.config.vMinor +
+                "." +
+                row.config.vRev +
+                ")"}
+        )),
     },
     {
       id: "delete",

--- a/frontend/src/components/NetworkMembers/NetworkMembers.jsx
+++ b/frontend/src/components/NetworkMembers/NetworkMembers.jsx
@@ -101,9 +101,9 @@ function NetworkMembers({ network }) {
       name: "Peer status",
       minWidth: "100px",
       cell: (row) =>
-        (row.online == 0) ? (
+        (row.online === 0) ? (
           <Typography color="error">OFFLINE</Typography>
-        ) : ( (row.online == 1) ? (
+        ) : ( (row.online === 1) ? (
         
             <Typography style={{ color: "#008000" }}>
               {"ONLINE (v" +
@@ -123,7 +123,24 @@ function NetworkMembers({ network }) {
                 "." +
                 row.config.vRev +
                 ")"}
+            </Typography>
         )),
+    },
+    {
+      id: "physicalip",
+      name: "Physical IP / Latency",
+      minWidth: "220px",
+      cell: (row) =>
+      (row.online === 1) ? (
+        <p>
+          {row.physicalAddress +
+           "/" +
+           row.physicalPort}<br />{
+           "(" +
+           row.latency +
+           " ms)"}
+       </p>
+      ) : (""),
     },
     {
       id: "delete",


### PR DESCRIPTION
This updated pull request also integrates backend and frontend changes to display peer physical IP, port, and latency. 

Previous changes:
Made changes to backend service member.js to set peerData.online to:
- 0 if peer is not found in peers list (i.e. offline)
- 1 if peer is found in peers list and latency is not -1 (i.e. direct route)
- 2 if peer is found in peers list and latency is -1 (i.e. relayed connection)

Also updated frontend NetworkMembers.jsx to reflect changes made to backend service.

## Pull Request type

These changes have been tested on a development deployment. 

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, if latency is -1, Zero-UI indicates the peer as offline. Peer physical IP address, port, and latency are not shown.

Issue Number: #42 & #43

## What is the new behavior?

Offline clients will not appear when the API is polled, but will still appear in the database; therefore, peers not found in the members list will be marked as offline, peers with a latency value of -1 will be marked as relayed, and peers with a valid latency value will be marked as online.

There is a new column on the frontend which displays peer physical IP, port, and latency. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Please see issue #42 and #43

I have not been able to find where the ZT controller keeps the last-online information yet.

I am new to contributing code via GitHub as well as programming JavaScript. Please let me know if I am doing anything wrong and what I can do to improve it. These code changes have been tested in a development environment. Screenshot of new features below. Thanks!

![Screenshot 2021-12-19 033044](https://user-images.githubusercontent.com/14115751/146674330-dd8a9ec2-8187-4e87-be8b-7b0291c2fb4b.jpg)
