### PR TITLE
Fix crash when network had no IP ranges

### DIFF
--- a/frontend/src/components/HomeLoggedIn/components/NetworkButton/NetworkButton.jsx
+++ b/frontend/src/components/HomeLoggedIn/components/NetworkButton/NetworkButton.jsx
@@ -20,6 +20,7 @@ function NetworkButton({ network }) {
           <Hidden mdDown>
             <ListItem className={classes.cidr}>
               {network["config"]["ipAssignmentPools"] &&
+                network["config"]["ipAssignmentPools"][0] &&
                 getCIDRAddress(
                   network["config"]["ipAssignmentPools"][0]["ipRangeStart"],
                   network["config"]["ipAssignmentPools"][0]["ipRangeEnd"]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Application no longer crashes when a network does not have any IP ranges. It simply does not show the IP ranges for the network that does not have IP ranges on the dashboard. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

![image](https://user-images.githubusercontent.com/14946926/165208595-e1df825b-9206-408c-85ee-8cce484a1ede.png)

