### PR TITLE
feat: add file download support

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -12,6 +12,7 @@ const authRoutes = require("./routes/auth");
 const networkRoutes = require("./routes/network");
 const memberRoutes = require("./routes/member");
 const controllerRoutes = require("./routes/controller");
+const downFileRoutes = require("./routes/downfile");
 
 const app = express();
 
@@ -64,6 +65,7 @@ routerController.use("", controllerRoutes);
 app.use("/auth", authRoutes);
 app.use("/api", routerAPI); // offical SaaS API compatible
 app.use("/controller", routerController); // other controller-specific routes
+app.use("/downfile", downFileRoutes); // file download routes
 
 // error handlers
 app.get("*", async function (req, res) {

--- a/backend/bin/www
+++ b/backend/bin/www
@@ -7,26 +7,64 @@ require("dotenv").config();
 
 var app = require("../app");
 var debug = require("debug")("zero-ui:server");
+var fs = require("fs");
 var http = require("http");
+var https = require("https");
+var path = require("path");
+
+const cert_path = path.join(__dirname, "..", "tls", "fullchain.pem");
+const privkey_path = path.join(__dirname, "..", "tls", "privkey.pem");
+
+let can_read_cert = true,
+  can_read_privkey = true;
+let statOptions = { throwIfNoEntry: false };
+let cert_stat = fs.statSync(cert_path, statOptions);
+let privkey_stat = fs.statSync(privkey_path, statOptions);
+
+if (!cert_stat) {
+  console.error(`cannot read cert at ${cert_path}`);
+  can_read_cert = false;
+}
+
+if (!privkey_stat) {
+  console.error(`cannot read privkey at ${privkey_path}`);
+  can_read_privkey = false;
+}
+
+let can_use_tls = can_read_cert && can_read_privkey;
+let server;
+if (can_use_tls) {
+  // only start HTTP server if we cannot find cert and key.
+  let option = {
+    key: fs.readFileSync(privkey_path),
+    cert: fs.readFileSync(cert_path),
+    honorCipherOrder: true,
+    minVersion: "TLSv1.3",
+  };
+  server = https.createServer(option, app);
+  debug("setting up TLS server");
+} else {
+  server = http.createServer(app);
+  debug("setting up HTTP server");
+}
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || "4000");
+var port = normalizePort(process.env.ZU_LISTEN_PORT || "4000");
 app.set("port", port);
-
-/**
- * Create HTTP server.
- */
-
-var server = http.createServer(app);
 
 /**
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port, process.env.LISTEN_ADDRESS || "0.0.0.0");
+if (can_use_tls) {
+  // only bind to all network interfaces if TLS is available.
+  server.listen(port, process.env.LISTEN_ADDRESS || "0.0.0.0");
+} else {
+  server.listen(port, process.env.LISTEN_ADDRESS || "localhost");
+}
 server.on("error", onError);
 server.on("listening", onListening);
 

--- a/backend/routes/downfile.js
+++ b/backend/routes/downfile.js
@@ -1,0 +1,21 @@
+const express = require("express");
+const path = require("path");
+const router = express.Router();
+
+const auth = require("../services/auth");
+
+router.get("/:downfilename", async function (req, res) {
+  const ret = await auth.isUserLoggedIn(req);
+  if (ret) {
+    const filename = req.params.downfilename;
+    res.sendFile(
+      path.join(__dirname, "..", "..", "frontend", "down_folder", filename)
+    );
+  } else {
+    res
+      .status(401)
+      .json({ error: "401 Not authorized, must Login to download" });
+  }
+});
+
+module.exports = router;

--- a/backend/services/auth.js
+++ b/backend/services/auth.js
@@ -35,3 +35,16 @@ async function isAuthorized(req, res, next) {
     }
   }
 }
+
+exports.isUserLoggedIn = isUserLoggedIn;
+async function isUserLoggedIn(req) {
+  if (process.env.ZU_DISABLE_AUTH === "true") {
+    // assuming logged in
+    return true;
+  }
+  if (!req.token) {
+    return false;
+  }
+  const user = await db.get("users").find({ token: req.token }).value();
+  return !!user ? true : false;
+}

--- a/backend/utils/controller-api.js
+++ b/backend/utils/controller-api.js
@@ -7,7 +7,21 @@ var token;
 if (process.env.ZU_CONTROLLER_TOKEN) {
   token = process.env.ZU_CONTROLLER_TOKEN;
 } else {
-  token = fs.readFileSync("/var/lib/zerotier-one/authtoken.secret", "utf8");
+  if (process.platform === "unix") {
+    token = fs.readFileSync("/var/lib/zerotier-one/authtoken.secret", "utf8");
+  } else if (process.platform === "win32") {
+    token = fs.readFileSync(
+      "C:\\ProgramData\\ZeroTier\\One\\authtoken.secret",
+      "utf8"
+    );
+  } else if (process.platform === "darwin") {
+    token = fs.readFileSync(
+      "/Library/Application Support/ZeroTier/One/authtoken.secret",
+      "utf8"
+    );
+  } else {
+    throw `Unsupported platform ${process.platform}`;
+  }
 }
 
 module.exports = axios.create({

--- a/frontend/src/components/HomeLoggedIn/HomeLoggedIn.jsx
+++ b/frontend/src/components/HomeLoggedIn/HomeLoggedIn.jsx
@@ -5,6 +5,7 @@ import { Divider, Button, Grid, Typography, Box } from "@material-ui/core";
 import useStyles from "./HomeLoggedIn.styles";
 
 import NetworkButton from "./components/NetworkButton";
+import DownloadFile from "./components/DownloadFile";
 
 import API from "utils/API";
 import { generateNetworkConfig } from "utils/NetworkConfig";
@@ -40,6 +41,8 @@ function HomeLoggedIn() {
       >
         Create A Network
       </Button>
+      <Divider orientation="vertical" />
+      <DownloadFile />
       <Divider />
       <Grid container spacing={3} className={classes.container}>
         <Grid item xs={6}>

--- a/frontend/src/components/HomeLoggedIn/components/DownloadFile/DownloadFile.jsx
+++ b/frontend/src/components/HomeLoggedIn/components/DownloadFile/DownloadFile.jsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { useLocalStorage } from "react-use";
+import { TextField, Button, Snackbar } from "@material-ui/core";
+
+import axios from "axios";
+
+function DownloadFile() {
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+
+  const [filename, setFilename] = useState("planet");
+  const [errormsg, setErrormsg] = useState("");
+
+  const [token] = useLocalStorage("token", null);
+
+  const downloadFile = async (fileName) => {
+    if (!!!token) {
+      await handleDownFileErr(`Invalid token`);
+      return;
+    }
+    if (typeof filename === "undefined" || filename.length === 0) {
+      await handleDownFileErr(`Invalid file name [${filename}]`);
+      return;
+    }
+    let ret;
+    ret = await axios
+      .create({
+        baseURL: `/downfile/`,
+        responseType: "arraybuffer",
+        withCredentials: "true",
+        headers:
+          localStorage.getItem("disableAuth") === "true"
+            ? {}
+            : {
+                Authorization: `Bearer ${token}`,
+              },
+      })
+      .get(`${fileName}`)
+      .then((resp) => {
+        const blobUrl = window.URL.createObjectURL(
+          new Blob([resp.data], { type: "application/octet-stream" })
+        );
+        const tmpLink = document.createElement("a");
+        tmpLink.style.display = "none";
+        tmpLink.href = blobUrl;
+        tmpLink.setAttribute("download", `${fileName}`);
+        if (typeof tmpLink.download === "undefined") {
+          tmpLink.setAttribute("target", "_blank");
+        }
+        document.body.appendChild(tmpLink);
+        tmpLink.click();
+        document.body.removeChild(tmpLink);
+        window.URL.revokeObjectURL(blobUrl);
+      })
+      .catch(async (e) => {
+        let errmsg = `downfile(${fileName}): ${e}: ${ret}`;
+        await handleDownFileErr(errmsg);
+      });
+  };
+
+  const handleDownFileBtnClick = async () => {
+    await downloadFile(filename);
+  };
+
+  const handleDownFileErr = async (errormsg) => {
+    setErrormsg(errormsg);
+    setSnackbarOpen(true);
+    let sleep = function (ms) {
+      return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+      });
+    };
+    await sleep(3 * 1000);
+    setSnackbarOpen(false);
+    setErrormsg("");
+  };
+
+  return (
+    <>
+      <TextField
+        value={filename}
+        onChange={(e) => {
+          setFilename(e.target.value);
+        }}
+        margin="dense"
+        label="File name to download"
+        type="text"
+      />
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleDownFileBtnClick}
+      >
+        Download file
+      </Button>
+      <Snackbar
+        open={snackbarOpen}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+        message={errormsg}
+      />
+    </>
+  );
+}
+
+export default DownloadFile;

--- a/frontend/src/components/HomeLoggedIn/components/DownloadFile/index.jsx
+++ b/frontend/src/components/HomeLoggedIn/components/DownloadFile/index.jsx
@@ -1,0 +1,1 @@
+export { default } from "./DownloadFile";


### PR DESCRIPTION
feat: backend: new api to download file such as planet

/PROJECT/frontend/down_folder/
http://locahost:4000/downfile/:downfilename

feat: frontend: add file download component for ease of use

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No download support

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Drop files you want to download into folder: `/PROJECT/frontend/down_folder/`
- If no token is provided, reject with 401 Unauthorized.
- After logging in, an input file that the user wants to download, such as the planet file for pure self-hosting controller.
- Prompt a dialog to download the file
- Advanced users can construct the request manually.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Testing docker image: https://hub.docker.com/r/wongsyrone/ztcontrollerzerouiwithplanetpatch

Example Usage:

```
docker run --rm -d -ti --name myztcontroller -v /root/zt-controller-docker/identity.public:/app/config/identity.public -v /root/zt-controller-docker/identity.secret:/app/config/identity.secret -v /root/zt-controller-docker/authtoken.secret:/app/config/authtoken.secret -v /root/zt-controller-docker/planet:/app/config/planet -v/root/zt-controller-docker/controller.d:/app/config/controller.d -v/root/zt-controller-docker/zero-ui-db.json:/app/backend/data/db.json -e ZU_SECURE_HEADERS=false -e ZT_PRIMARY_PORT=9993 -e ZU_CONTROLLER_ENDPOINT=http://127.0.0.1:9993/ -e ZU_DEFAULT_USERNAME=admin -e ZU_DEFAULT_PASSWORD=zero-ui -p 3000:3000 -p 4000:4000 -p 9993:9993 -p 9993:9993/udp wongsyrone/ztcontrollerzerouiwithplanetpatch:latest
```

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
