### PR TITLE
feat: add support to default authtoken location of major platforms

### DIFF
--- a/backend/utils/controller-api.js
+++ b/backend/utils/controller-api.js
@@ -7,7 +7,21 @@ var token;
 if (process.env.ZU_CONTROLLER_TOKEN) {
   token = process.env.ZU_CONTROLLER_TOKEN;
 } else {
-  token = fs.readFileSync("/var/lib/zerotier-one/authtoken.secret", "utf8");
+  if (process.platform === "unix") {
+    token = fs.readFileSync("/var/lib/zerotier-one/authtoken.secret", "utf8");
+  } else if (process.platform === "win32") {
+    token = fs.readFileSync(
+      "C:\\ProgramData\\ZeroTier\\One\\authtoken.secret",
+      "utf8"
+    );
+  } else if (process.platform === "darwin") {
+    token = fs.readFileSync(
+      "/Library/Application Support/ZeroTier/One/authtoken.secret",
+      "utf8"
+    );
+  } else {
+    throw `Unsupported platform ${process.platform}`;
+  }
 }
 
 module.exports = axios.create({


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Only *nix default authtoken.secret location provided.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Provide default authtoken.secret location for *nix, macos and windows if  ZU_CONTROLLER_TOKEN env is not found.
- Otherwise, read from ZU_CONTROLLER_TOKEN env.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
