### PR TITLE
Fix docker image build failure after node:lts-alpine changed to 18.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   zerotier:
-    image: zyclonite/zerotier:1.10.1
+    image: zyclonite/zerotier:1.10.2
     container_name: zu-controller
     restart: unless-stopped
     volumes:

--- a/docker/zero-ui/Dockerfile
+++ b/docker/zero-ui/Dockerfile
@@ -2,6 +2,7 @@ FROM --platform=$BUILDPLATFORM node:lts-alpine as frontend-build
 
 ENV INLINE_RUNTIME_CHUNK=false
 ENV GENERATE_SOURCEMAP=false
+ENV NODE_OPTIONS=--openssl-legacy-provider
 
 WORKDIR /app/frontend
 COPY yarn.lock .yarnrc.yml ./


### PR DESCRIPTION
Fix image build error. While there, also updated zerotier to latest minor version.

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Base image for building the frontend is referenced with its tag on
the Dockerfile (FROM node:lts-alpine). The tag has been recently
changed, and now points to version 18 of nodejs.

Attempting to build with new lts (v.18), results in an error when
building the frontend:
 > [frontend-build 8/8] RUN yarn build:
#0 3.553 Creating an optimized production build...                                                                                                                                                                   
#0 4.139 Error: error:0308010C:digital envelope routines::unsupported 

Issue Number: N/A

## What is the new behavior?

Adding the ENV var has fixed the build issue, and the container image
is now produced without errors.

## Does this introduce a breaking change?

- [ ] Yes
- [X ] No

