### PR TITLE
feat: add ipv6 support

### DIFF
--- a/frontend/src/components/NetworkSettings/NetworkSettings.jsx
+++ b/frontend/src/components/NetworkSettings/NetworkSettings.jsx
@@ -13,6 +13,7 @@ import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 import ManagedRoutes from "./components/ManagedRoutes";
 import IPv4AutoAssign from "./components/IPv4AutoAssign";
+import IPv6AutoAssign from "./components/IPv6AutoAssign";
 
 import API from "utils/API";
 import { parseValue, replaceValue, setValue } from "utils/ChangeHelper";
@@ -104,10 +105,13 @@ function NetworkSettings({ network, setNetwork }) {
               handleChange={handleChange}
             />
           </Grid>
-          {/* TODO: */}
-          {/* <Grid item>
-            <Typography>IPv6 Auto-Assign</Typography>
-          </Grid> */}
+          <Grid item>
+            <IPv6AutoAssign
+              id={network["id"]}
+              v6AssignMode={network["config"]["v6AssignMode"]}
+              handleChange={handleChange}
+            />
+          </Grid>
           <Divider />
           <Grid item>
             <TextField

--- a/frontend/src/components/NetworkSettings/components/IPv6AutoAssign/IPv6AutoAssign.jsx
+++ b/frontend/src/components/NetworkSettings/components/IPv6AutoAssign/IPv6AutoAssign.jsx
@@ -24,25 +24,25 @@ function IPv6AutoAssign({ id, v6AssignMode, handleChange }) {
           />
           <span>ZeroTier RFC4193 (/128 for each device)</span>
           {v6AssignMode["rfc4193"] && (
-            <div>
-              <small style={{ marginLeft: '2rem', letterSpacing: '1px' }}>
-                <code>
-                  fd
-                  <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(0, 2)}</span>
-                  :
-                  <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(2, 6)}</span>
-                  :
-                  <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(6, 10)}</span>
-                  :
-                  <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(10, 12)}</span>
-                  99:93
-                  <span style={{ backgroundColor: '#ccffff' }}>__</span>
-                  :
-                  <span style={{ backgroundColor: '#ccffff' }}>____</span>
-                  :
-                  <span style={{ backgroundColor: '#ccffff' }}>____</span>
-                </code>
-              </small>
+            <div style={{ marginLeft: '4rem', letterSpacing: '1px' }}>
+              <code>
+                fd
+                <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(0, 2)}</span>
+                :
+                <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(2, 6)}</span>
+                :
+                <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(6, 10)}</span>
+                :
+                <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(10, 14)}</span>
+                :
+                <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(14, 16)}</span>
+                99:93
+                <span style={{ backgroundColor: '#ccffff' }}>__</span>
+                :
+                <span style={{ backgroundColor: '#ccffff' }}>____</span>
+                :
+                <span style={{ backgroundColor: '#ccffff' }}>____</span>
+              </code>
             </div>
           )}
         </Grid>
@@ -61,6 +61,38 @@ function IPv6AutoAssign({ id, v6AssignMode, handleChange }) {
             }}
           />
           <span>ZeroTier 6PLANE (/80 routable for each device)</span>
+          {v6AssignMode["6plane"] && (
+            <div style={{ marginLeft: '4rem', letterSpacing: '1px' }}>
+              <code>
+                fc
+                {
+                  (() => {
+                    const sixPlaneID = id.match(/.{1,2}/g)
+                    .map((substr, idx, arr) => parseInt(substr, 16) ^ parseInt(arr[idx + 4], 16))
+                    .map((byte) => byte.toString(16).toLowerCase())
+                    .map((byte) => (byte.length === 2) ? byte : '0' + byte)
+                    .slice(0, 4)
+                    .join('')
+                    return (
+                      <>
+                        <span style={{ backgroundColor: '#ffffcc' }}>{sixPlaneID.slice(0, 2)}</span>
+                        :
+                        <span style={{ backgroundColor: '#ffffcc' }}>{sixPlaneID.slice(2, 6)}</span>
+                        :
+                        <span style={{ backgroundColor: '#ffffcc' }}>{sixPlaneID.slice(6, 8)}</span>
+                      </>
+                    )
+                  })()
+                }
+                <span style={{ backgroundColor: '#ccffff' }}>__</span>
+                :
+                <span style={{ backgroundColor: '#ccffff' }}>____</span>
+                :
+                <span style={{ backgroundColor: '#ccffff' }}>____</span>
+                :0000:0000:0001
+              </code> 
+            </div>
+          )}
         </Grid>
 
         {/* TODO: Implement v6 ipAssignmentPools, might break ipv4 pool settings */}

--- a/frontend/src/components/NetworkSettings/components/IPv6AutoAssign/IPv6AutoAssign.jsx
+++ b/frontend/src/components/NetworkSettings/components/IPv6AutoAssign/IPv6AutoAssign.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {
+  Checkbox,
+  Grid,
+  Typography,
+} from "@material-ui/core";
+
+function IPv6AutoAssign({ id, v6AssignMode, handleChange }) {
+  return (
+    <>
+      <Typography>IPv6 Auto-Assign</Typography>
+      <Grid container direction="column">
+        <Grid item>
+          <Checkbox
+            checked={v6AssignMode["rfc4193"]}
+            color="primary"
+            onChange={(e) => {
+              handleChange("config", "v6AssignMode", "custom", {
+                "rfc4193": e.target.checked,
+                "6plane": v6AssignMode["6plane"],
+                "zt": v6AssignMode["zt"],
+              })(null)
+            }}
+          />
+          <span>ZeroTier RFC4193 (/128 for each device)</span>
+          {v6AssignMode["rfc4193"] && (
+            <div>
+              <small style={{ marginLeft: '2rem', letterSpacing: '1px' }}>
+                <code>
+                  fd
+                  <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(0, 2)}</span>
+                  :
+                  <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(2, 6)}</span>
+                  :
+                  <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(6, 10)}</span>
+                  :
+                  <span style={{ backgroundColor: '#ffffcc' }}>{id.slice(10, 12)}</span>
+                  99:93
+                  <span style={{ backgroundColor: '#ccffff' }}>__</span>
+                  :
+                  <span style={{ backgroundColor: '#ccffff' }}>____</span>
+                  :
+                  <span style={{ backgroundColor: '#ccffff' }}>____</span>
+                </code>
+              </small>
+            </div>
+          )}
+        </Grid>
+
+
+        <Grid item>
+          <Checkbox
+            checked={v6AssignMode["6plane"]}
+            color="primary"
+            onChange={(e) => {
+              handleChange("config", "v6AssignMode", "custom", {
+                "rfc4193": v6AssignMode["rfc4193"],
+                "6plane": e.target.checked,
+                "zt": v6AssignMode["zt"],
+              })(null)
+            }}
+          />
+          <span>ZeroTier 6PLANE (/80 routable for each device)</span>
+        </Grid>
+
+        {/* TODO: Implement v6 ipAssignmentPools, might break ipv4 pool settings */}
+        {/* <Grid>
+          <Checkbox
+            checked={v6AssignMode["zt"]}
+            color="primary"
+            onChange={(e) => {
+              handleChange("config", "v6AssignMode", "custom", {
+                "rfc4193": v6AssignMode["rfc4193"],
+                "6plane": v6AssignMode["6plane"],
+                "zt": e.target.checked,
+              })(null)
+            }}
+          />
+          <span>Auto-Assign from Range</span>
+        </Grid> */}
+      </Grid>
+    </>
+  );
+}
+
+export default IPv6AutoAssign;

--- a/frontend/src/components/NetworkSettings/components/IPv6AutoAssign/index.jsx
+++ b/frontend/src/components/NetworkSettings/components/IPv6AutoAssign/index.jsx
@@ -1,0 +1,1 @@
+export { default } from "./IPv6AutoAssign";


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Lack of IPv6 Auto Assignment support.

Issue Number: #6 #89

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

What's working (These are tested on another ZT client.):
- Add checkbox to auto-assign ZeroTier RFC4193 IP
- Add checkbox to auto-assign ZeroTier 6PLANE IP
- Add hints about what RFC4193/6PLANE IPs would look like (the yellow part is the network addr; the blue part is the client addr.; IPv6 hints [ref]([gist.github.com/laduke/fa1e9a68a79d9038ab117ad0ab69927a](https://gist.github.com/laduke/fa1e9a68a79d9038ab117ad0ab69927a)))


<img width="478" alt="image" src="https://github.com/dec0dOS/zero-ui/assets/9292238/1a2c6f44-df08-408c-9abf-537932489ddc">

What's not working yet:
- Auto-Assign from a specific Range. Would need to add two more textboxes, and the `handleChange` might affect IPv4's ipAssignmentPools. Haven't tried it, tho.
- <del>Hint about what 6PLANE IP would look like. I don't know where's the yellow part of 6PLANE ip. </del>
- Show assigned IP on the members page. (I haven't find the assigned IP in the `config` object yet. might need to take a deeper look at zero-ui backend)

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/9292238/232279159-751016fc-40c8-4b1b-a2e8-49ace9b5812d.png">


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
